### PR TITLE
Bug fix with the SubHeader content

### DIFF
--- a/src/components/SubHeader/subheader.module.css
+++ b/src/components/SubHeader/subheader.module.css
@@ -39,6 +39,10 @@
   margin: 20px 0 20px 0;
 }
 
+.notShow div {
+  display: none;
+}
+
 .open {
   height: 300px;
   transition: height 0.3s ease-in-out;


### PR DESCRIPTION
`<Link>` tags no longer show when SubHeader component is closed
This was due to the fact that this component behavior with max height

fixes #18 