### PR TITLE
Pagetitle updated

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ function App() {
   const [pageTitleHeight, setPageTitleHeight] = useState(350);
   const [lastPosition, setLastPosition] = useState(0);
   const [isSticky, setIsSticky] = useState(false);
+  const [pageTitleFontSize, setPageTitleFontSize] = useState(80);
   const subHeaderRef = useRef<HTMLDivElement>(null);
   const location = useLocation();
 
@@ -69,6 +70,7 @@ function App() {
     const scrollPosition = window.scrollY;
     if (scrollPosition >= 160 && !isSticky) {
       setPageTitleHeight(150);
+      setPageTitleFontSize(50);
       setLastPosition(160);
       setIsSticky(true);
     } else if (scrollPosition < 160 && isSticky) {
@@ -76,7 +78,9 @@ function App() {
     } else if (!isSticky) {
       console.log(scrollPosition);
       const newHeight = Math.max(150, 350 - scrollPosition * 2);
+      const newFontSize = Math.max(50, 80 - scrollPosition / 3.2);
       setPageTitleHeight(newHeight);
+      setPageTitleFontSize(newFontSize);
     }
   };
 
@@ -110,6 +114,7 @@ function App() {
       <PageTitle
         currentPage={currentPage}
         pageTitleHeight={pageTitleHeight}
+        pageTitleFontSize={pageTitleFontSize}
         isSticky={isSticky}
         lastPosition={lastPosition}
       ></PageTitle>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,9 @@ function App() {
     accessories: false,
     angels: false,
   });
+  const [pageTitleHeight, setPageTitleHeight] = useState(350);
+  const [lastPosition, setLastPosition] = useState(0);
+  const [isSticky, setIsSticky] = useState(false);
   const subHeaderRef = useRef<HTMLDivElement>(null);
   const location = useLocation();
 
@@ -62,12 +65,29 @@ function App() {
     }
   };
 
+  const handleDynamicHeight = () => {
+    const scrollPosition = window.scrollY;
+    if (scrollPosition >= 160 && !isSticky) {
+      setPageTitleHeight(150);
+      setLastPosition(160);
+      setIsSticky(true);
+    } else if (scrollPosition < 160 && isSticky) {
+      setIsSticky(false);
+    } else if (!isSticky) {
+      console.log(scrollPosition);
+      const newHeight = Math.max(150, 350 - scrollPosition * 2);
+      setPageTitleHeight(newHeight);
+    }
+  };
+
   useEffect(() => {
     document.addEventListener("mousedown", handleMouseDown);
     document.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("scroll", handleDynamicHeight);
     return () => {
       document.removeEventListener("mousedown", handleMouseDown);
       document.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("scroll", handleDynamicHeight);
     };
   });
 
@@ -87,7 +107,12 @@ function App() {
         subHeaderRef={subHeaderRef}
       ></SubHeader>
       <div className="hiderContainer"></div>
-      <PageTitle currentPage={currentPage}></PageTitle>
+      <PageTitle
+        currentPage={currentPage}
+        pageTitleHeight={pageTitleHeight}
+        isSticky={isSticky}
+        lastPosition={lastPosition}
+      ></PageTitle>
       <div className="mainContentContainer">
         <Routes>
           <Route path="/" element={<Home></Home>}></Route>

--- a/src/components/PageTitle/PageTitle.tsx
+++ b/src/components/PageTitle/PageTitle.tsx
@@ -14,6 +14,7 @@ interface PageTitleProps {
     contacts: boolean;
   };
   pageTitleHeight: number;
+  pageTitleFontSize: number;
   isSticky: boolean;
   lastPosition: number;
 }
@@ -21,6 +22,7 @@ interface PageTitleProps {
 export default function PageTitle({
   currentPage,
   pageTitleHeight,
+  pageTitleFontSize,
   isSticky,
   lastPosition,
 }: Readonly<PageTitleProps>) {
@@ -59,7 +61,8 @@ export default function PageTitle({
         height: `${pageTitleHeight}px`,
         position: isSticky ? "fixed" : "relative",
         marginTop: !isSticky ? "35dvh" : `${lastPosition}px`,
-        width: isSticky ? "100%" : ""
+        width: isSticky ? "100%" : "",
+        fontSize: `${pageTitleFontSize}px`,
       }}
     >
       {pageTitle}

--- a/src/components/PageTitle/PageTitle.tsx
+++ b/src/components/PageTitle/PageTitle.tsx
@@ -13,12 +13,20 @@ interface PageTitleProps {
     angels: boolean;
     contacts: boolean;
   };
+  pageTitleHeight: number;
+  isSticky: boolean;
+  lastPosition: number;
 }
 
-export default function PageTitle({ currentPage }: Readonly<PageTitleProps>) {
+export default function PageTitle({
+  currentPage,
+  pageTitleHeight,
+  isSticky,
+  lastPosition,
+}: Readonly<PageTitleProps>) {
   const [pageTitle, setPageTitle] = useState("Home");
   const [animate, setAnimate] = useState(false);
-
+  console.log(lastPosition);
   const location = useLocation().pathname;
   useEffect(() => {
     Object.entries(currentPage).map(([pages, isActive]) => {
@@ -47,6 +55,12 @@ export default function PageTitle({ currentPage }: Readonly<PageTitleProps>) {
       className={`${styles.mainPageTitleContainer} ${
         animate ? styles.animate : ""
       }`}
+      style={{
+        height: `${pageTitleHeight}px`,
+        position: isSticky ? "fixed" : "relative",
+        marginTop: !isSticky ? "35dvh" : `${lastPosition}px`,
+        width: isSticky ? "100%" : ""
+      }}
     >
       {pageTitle}
     </div>

--- a/src/components/PageTitle/pagetitle.module.css
+++ b/src/components/PageTitle/pagetitle.module.css
@@ -1,9 +1,7 @@
 .mainPageTitleContainer {
   width: calc(100% + 16px);
-  height: 170px;
   margin-left: -8px;
   margin-right: -8px;
-  margin-top: 180px;
   background-color: coral;
   display: flex;
   justify-content: center;

--- a/src/components/PageTitle/pagetitle.module.css
+++ b/src/components/PageTitle/pagetitle.module.css
@@ -6,7 +6,6 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  font-size: 50px;
   box-shadow: 50px 0px 75px 10px rgba(141, 141, 141, 0.703);
   transition: transform 0.5s ease-in-out, opacity 0.5s ease-in-out;
   -webkit-transition: transform 0.5s ease-in-out, opacity 0.5s ease-in-out;
@@ -27,7 +26,7 @@
     -moz-transform: translateY(-100%);
     -ms-transform: translateY(-100%);
     -o-transform: translateY(-100%);
-}
+  }
   to {
     transform: translateY(0);
     opacity: 1;
@@ -35,5 +34,5 @@
     -moz-transform: translateY(0);
     -ms-transform: translateY(0);
     -o-transform: translateY(0);
-}
+  }
 }


### PR DESCRIPTION
PageTitle now strats from the middle of the screen, with a mych bigger height, and by scrolling its:

1. Height reduces
2. Goes up with the scroll (obvios)
3. when reaches minimum height of 150px, just scroll to the bottom of the Header component
4. Whe it reaches there, its position stays fixed
5. Also the Font size also starts much bigger, to set smaller by each scroll

closes #19 