### PR TITLE
Pagetitle fix

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,10 +25,10 @@ function App() {
     accessories: false,
     angels: false,
   });
-  const [pageTitleHeight, setPageTitleHeight] = useState(350);
+  const [pageTitleHeight, setPageTitleHeight] = useState(300);
   const [lastPosition, setLastPosition] = useState(0);
   const [isSticky, setIsSticky] = useState(false);
-  const [pageTitleFontSize, setPageTitleFontSize] = useState(80);
+  const [pageTitleFontSize, setPageTitleFontSize] = useState(100);
   const subHeaderRef = useRef<HTMLDivElement>(null);
   const location = useLocation();
 
@@ -68,17 +68,17 @@ function App() {
 
   const handleDynamicHeight = () => {
     const scrollPosition = window.scrollY;
-    if (scrollPosition >= 160 && !isSticky) {
+    if (scrollPosition >= 100 && !isSticky) {
       setPageTitleHeight(150);
       setPageTitleFontSize(50);
-      setLastPosition(160);
+      setLastPosition(150);
       setIsSticky(true);
-    } else if (scrollPosition < 160 && isSticky) {
+    } else if (scrollPosition < 100 && isSticky) {
       setIsSticky(false);
     } else if (!isSticky) {
       console.log(scrollPosition);
-      const newHeight = Math.max(150, 350 - scrollPosition * 2);
-      const newFontSize = Math.max(50, 80 - scrollPosition / 3.2);
+      const newHeight = Math.max(150, 300 - scrollPosition * 2);
+      const newFontSize = Math.max(50, 100 - scrollPosition / 1.5);
       setPageTitleHeight(newHeight);
       setPageTitleFontSize(newFontSize);
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,6 +97,10 @@ function App() {
 
   useEffect(() => {
     scrollTo(0, 0);
+    setLastPosition(0)
+    setPageTitleHeight(300)
+    setIsSticky(false)
+    setPageTitleFontSize(100)
   }, [location]);
 
   return (

--- a/src/components/PageTitle/PageTitle.tsx
+++ b/src/components/PageTitle/PageTitle.tsx
@@ -60,7 +60,7 @@ export default function PageTitle({
       style={{
         height: `${pageTitleHeight}px`,
         position: isSticky ? "fixed" : "relative",
-        marginTop: !isSticky ? "35dvh" : `${lastPosition}px`,
+        marginTop: !isSticky ? "250px" : `${lastPosition}px`,
         width: isSticky ? "100%" : "",
         fontSize: `${pageTitleFontSize}px`,
       }}

--- a/src/components/PageTitle/pagetitle.module.css
+++ b/src/components/PageTitle/pagetitle.module.css
@@ -6,6 +6,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  z-index: -1;
   box-shadow: 50px 0px 75px 10px rgba(141, 141, 141, 0.703);
   transition: transform 0.5s ease-in-out, opacity 0.5s ease-in-out;
   -webkit-transition: transform 0.5s ease-in-out, opacity 0.5s ease-in-out;


### PR DESCRIPTION
All bugs that appeared from #22 are now adressed (hopping its all of them). Here's a list:

1. PageTitle container sticked to far up when the sroll threshold was passed
2. When scroll position is higher than the threshold and the div is sticked to the top (bottom of the header div), when switching locations, the new pagetitle would stay in the same place, despite the page scrolling to 0
3. SubHeader container would stay behind the PageTitle

fixes #23 