### PR TITLE
PageTitle and Header height for smaller screens (in height)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -19,6 +19,15 @@
   background-color: var(--light-theme-background-color);
 }
 
+.hiderContainer.smallHeightScreen {
+  height: 110px;
+}
+
+.hiderContainer2.smallHeightScreen {
+  top: 108px;
+  height: 90px;
+}
+
 .mainContentContainer {
   min-height: 200vh;
   margin: 370px 50px 450px 50px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,16 +25,18 @@ function App() {
     accessories: false,
     angels: false,
   });
-  const [pageTitleHeight, setPageTitleHeight] = useState(250);
+  const [pageTitleHeight, setPageTitleHeight] = useState(
+    window.innerHeight >= 800 ? 250 : 180
+  );
   const [lastPosition, setLastPosition] = useState(0);
   const [isSticky, setIsSticky] = useState(false);
   const [pageTitleFontSize, setPageTitleFontSize] = useState(
-    window.innerHeight >= 800 ? 120 : 100
+    window.innerHeight >= 800 ? 120 : 90
   );
   const subHeaderRef = useRef<HTMLDivElement>(null);
   const location = useLocation();
   const [windowHeight, setWindowHeight] = useState(window.innerHeight);
-  console.log(windowHeight);
+
   const handleResize = () => {
     setWindowHeight(window.innerHeight);
   };
@@ -76,6 +78,7 @@ function App() {
   const handleDynamicHeight = () => {
     const scrollPosition = window.scrollY;
     if (windowHeight >= 800) {
+      console.log(scrollPosition)
       if (scrollPosition >= 200 && !isSticky) {
         setPageTitleHeight(150);
         setPageTitleFontSize(70);
@@ -91,20 +94,25 @@ function App() {
       }
     } else {
       if (scrollPosition >= 100 && !isSticky) {
-        setPageTitleHeight(100);
-        setPageTitleFontSize(50);
-        setLastPosition(150);
+        setPageTitleHeight(90);
+        setPageTitleFontSize(40);
+        setLastPosition(120);
         setIsSticky(true);
       } else if (scrollPosition < 100 && isSticky) {
         setIsSticky(false);
       } else if (!isSticky) {
-        const newHeight = Math.max(100, 250 - scrollPosition * 3);
-        const newFontSize = Math.max(50, 100 - scrollPosition);
+        const newHeight = Math.max(90, 180 - scrollPosition * 3);
+        const newFontSize = Math.max(40, 90 - scrollPosition * 1.5);
         setPageTitleHeight(newHeight);
         setPageTitleFontSize(newFontSize);
       }
     }
   };
+
+  useEffect(() => {
+    handleDynamicHeight();
+
+  }, [windowHeight]);
 
   useEffect(() => {
     document.addEventListener("mousedown", handleMouseDown);
@@ -122,12 +130,10 @@ function App() {
   useEffect(() => {
     scrollTo(0, 0);
     setLastPosition(0);
-    setPageTitleHeight(250);
+    setPageTitleHeight(window.innerHeight >= 800 ? 250 : 180);
     setIsSticky(false);
-    setPageTitleFontSize(100);
+    setPageTitleFontSize(window.innerHeight >= 800 ? 120 : 90);
   }, [location]);
-
-  useEffect(() => {});
 
   return (
     <div>
@@ -135,13 +141,14 @@ function App() {
         currentPage={currentPage}
         setCurrentPage={setCurrentPage}
         setIsSubHeaderOpen={setIsSubHeaderOpen}
+        windowHeight={windowHeight}
       ></Header>
       <SubHeader
         isSubHeaderOpen={isSubHeaderOpen}
         subHeaderRef={subHeaderRef}
       ></SubHeader>
-      <div className="hiderContainer"></div>
-      <div className="hiderContainer2"></div>
+      <div className={`hiderContainer ${windowHeight >= 800 ? "" : "smallHeightScreen"}`}></div>
+      <div className={`hiderContainer2 ${windowHeight >= 800 ? "" : "smallHeightScreen"}`}></div>
       <PageTitle
         currentPage={currentPage}
         pageTitleHeight={pageTitleHeight}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -33,12 +33,14 @@ interface HeaderProps {
       angels: boolean;
     }>
   >;
+  windowHeight: number;
 }
 
 export default function Header({
   currentPage,
   setCurrentPage,
   setIsSubHeaderOpen,
+  windowHeight,
 }: Readonly<HeaderProps>) {
   const navigate = useNavigate();
   const restartCurrentPage = () => {
@@ -71,9 +73,16 @@ export default function Header({
   };
 
   return (
-    <div id="header" className={styles.mainHeaderContainer}>
+    <div
+      id="header"
+      className={`${styles.mainHeaderContainer} ${
+        windowHeight >= 800 ? "" : styles.smallHeightScreen
+      }`}
+    >
       <div
-        className={styles.logoContainer}
+        className={`${styles.logoContainer} ${
+          windowHeight >= 800 ? "" : styles.smallHeightScreen
+        }`}
         onClick={() => {
           setNewCurrentPage("home");
           navigate("/");
@@ -87,7 +96,11 @@ export default function Header({
       >
         <img src={Logo} alt="Flor de Linha Logo" />
       </div>
-      <div className={styles.headers}>
+      <div
+        className={`${styles.headers} ${
+          windowHeight >= 800 ? "" : styles.smallHeightScreen
+        }`}
+      >
         <div
           className={`${styles.headerPage} ${
             currentPage.about ? styles.current : ""

--- a/src/components/Header/header.module.css
+++ b/src/components/Header/header.module.css
@@ -9,6 +9,10 @@
   z-index: 3;
 }
 
+.mainHeaderContainer.smallHeightScreen {
+  height: 6rem;
+}
+
 .logoContainer {
   position: relative;
   cursor: pointer;
@@ -22,6 +26,11 @@
   -moz-transition: filter 0.3s ease-in-out, transform 0.3s ease-in-out;
   -ms-transition: filter 0.3s ease-in-out, transform 0.3s ease-in-out;
   -o-transition: filter 0.3s ease-in-out, transform 0.3s ease-in-out;
+}
+
+.logoContainer.smallHeightScreen img {
+  height: 6rem;
+  width: 6rem;
 }
 
 .logoContainer img:hover {
@@ -39,6 +48,10 @@
   align-items: center;
   gap: 10px;
   font-size: var(--big-screens-font-size);
+}
+
+.headers.smallHeightScreen {
+  font-size: var(--small-height-screens-font-size);
 }
 
 .headerPage {

--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,7 @@
   --light-theme-background-color: #f0f0f0ea; 
   --light-theme-text-color: #353535d3;
   --big-screens-font-size: 20px;
+  --small-height-screens-font-size: 17px;
   --small-screens-font-size: 10px;
   --header-color: #ece2dd;
   --link-hover: #fc888a;
@@ -16,6 +17,10 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+html {
+  scroll-behavior: smooth;
 }
 
 a {

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -6,9 +6,7 @@ interface HomeProps {
   windowHeight: number;
 }
 
-export default function Home({
-  windowHeight,
-}: Readonly<HomeProps>) {
+export default function Home({ windowHeight }: Readonly<HomeProps>) {
   const [visible, setVisible] = useState(false);
 
   const handleScroll = () => {
@@ -24,20 +22,9 @@ export default function Home({
   const handleSlowScroll = (event: WheelEvent) => {
     // Prevent default scroll behavior
     event.preventDefault();
-    const scrollPosition = window.scrollY;
 
     // Apply slower scrolling
-    if (scrollPosition >= 150) {
-      window.scrollBy({
-        top: event.deltaY * 1.2,
-        behavior: "smooth",
-      });
-    } else {
-      window.scrollBy({
-        top: event.deltaY * 1.5,
-        behavior: "smooth",
-      });
-    }
+    window.scrollBy(0, event.deltaY * 1);
   };
 
   useEffect(() => {
@@ -58,14 +45,12 @@ export default function Home({
         visible ? styles.visible : styles.disapear
       }`}
     >
-      <AppearAsScroll
-      >
+      <AppearAsScroll>
         <div style={{ height: "500px", backgroundColor: "#4caf50" }}>
           <h1>Bem-Vind@ à Flor de Linha</h1>
         </div>
       </AppearAsScroll>
-      <AppearAsScroll
-      >
+      <AppearAsScroll>
         <div style={{ height: "500px", backgroundColor: "red" }}>
           <h1>
             O objetivo desta loja é começar a ganhar algum para depois dar um
@@ -73,8 +58,7 @@ export default function Home({
           </h1>
         </div>
       </AppearAsScroll>
-      <AppearAsScroll
-      >
+      <AppearAsScroll>
         <div style={{ height: "1000px", backgroundColor: "yellow" }}>
           <h1>
             O objetivo desta loja é começar a ganhar algum para depois dar um


### PR DESCRIPTION
This PR updates the height, position and font sizes from the the Header and Pagetitle, depending on the height of the window
Also the containers used to hide the content scrolling behind these two components were updated
Slowing down de scroll speed was changed
Was tested in smaller screen, the only ISSUE was **that when resizing while Pagetitle was fixed, didnt update its height**
close #29 